### PR TITLE
fix: the last page is 404

### DIFF
--- a/src/pages/page/[page].astro
+++ b/src/pages/page/[page].astro
@@ -15,7 +15,7 @@ export async function getStaticPaths() {
 
   const firstPagePosts = allPosts.slice(0, 15);
   const remainingPosts = allPosts.slice(15);
-  const totalPages = Math.ceil(remainingPosts.length / 12);
+  const totalPages = 1 + Math.ceil(remainingPosts.length / 12);
 
   const paths = [
     {
@@ -24,7 +24,7 @@ export async function getStaticPaths() {
         page: {
           data: firstPagePosts,
           currentPage: 1,
-          lastPage: totalPages + 1,
+          lastPage: totalPages,
         },
       },
     },
@@ -35,7 +35,7 @@ export async function getStaticPaths() {
     paths.push({
       params: { page: i.toString() },
       props: {
-        page: { data: pagePosts, currentPage: i, lastPage: totalPages + 1 },
+        page: { data: pagePosts, currentPage: i, lastPage: totalPages },
       },
     });
   }


### PR DESCRIPTION
This bug is caused by `getStaticPaths` function does not generate the last page.

For example, there are 75 posts, the first page will render the first 15 posts due to the `firstPagePosts` in `src/pages/index.astro`. Then it also slices the first 15 posts as the first page's content in `[page].astro` and the rest posts divided by 12 as per page's content (the 12 here is because 12 is the real count for rendering posts in each normal page except the home page which is also the first page)

The `totalPages` should be the real page count used for pagination and page paths generating as its name, but the calculating for totalPages uses remainingPosts' length which excludes the first page. Although when passed to `lastPage`, it adds 1 to include the first page, but the iteration for generating paths still use `totalPages` as the loop end condition, so it will miss the last page.

e.g. when allPosts length is 75, the firstPagePosts length is 15, the remainingPosts length is 60, the totalPages will be 60 / 12 = 5

Then the for loop will iterate from 2 to 5, it will only generates the 2nd page, the 3rd page, the 4th page and the 5th page, now the pages will be 1,2,3,4,5. But there should has 6 pages with 75 posts (15 for the first page and 12 posts for each rest page)

Solution
1. Make `totalPages` to store the real page count with adding 1 which stand the first page to the existing pages calculating.
2. Use `totalPages` everywhere without extra calculating to make it consist with its name